### PR TITLE
doc(AWS/Redshift): create a document for Redshift

### DIFF
--- a/AWS/Redshift.md
+++ b/AWS/Redshift.md
@@ -1,0 +1,42 @@
+# Redshift
+
+AWS Redshift can be accessed directly from the Terminal with `psql`
+
+## Examples
+
+### `UNLOAD`
+
+The [`UNLOAD` command](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) is used to save database dumps onto AWS S3. The basic structure looks like this:
+
+```sql
+UNLOAD('SELECT * FROM «table»')
+TO 's3://«location»'
+CREDENTIALS 'aws_access_key_id=«key»;aws_secret_access_key=«secret»';
+```
+
+Hence, a common `UNLOAD` command may look like this in its near-final form:
+
+```sql
+UNLOAD('SELECT * FROM «table»')
+TO 's3://«bucket»/«path».csv'
+CREDENTIALS 'aws_access_key_id=«key»;aws_secret_access_key=«secret»'
+ESCAPE
+ADDQUOTES
+PARALLEL OFF
+DELIMITER AS ',';
+```
+
+#### Edge-Cases
+
+* Instead of using double-quotes, use escaped single quotes, like so:
+  ```sql
+  UNLOAD('SELECT * FROM «table» WHERE «field»=\'«value»\'') TO 's3://«location»';
+  ```
+
+* It is impossible to `UNLOAD` with a `LIMIT` in the query. Therefore, [one solution](https://stackoverflow.com/a/32149417/545590) is to use a nested limit, like so:
+
+  ```sql
+  UNLOAD('SELECT * FROM «table» WHERE «id» IN (
+    SELECT id FROM «table» LIMIT «limit»
+  )') TO 's3://«location»';
+  ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added:
 - Initial project setup
+- AWS Redshift doc

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A collection of examples and edge-cases of commonly-used tools
 
 TK
 
+## General Notes
+
+* **Variable Notation** - because this notebook is a collection of examples from all kinds of programming paradigms, a common variable notation is bound to clash with at least some languages and tools. See list below for a few examples. That's why this project is going to use a special notation of [Guillemets](https://en.wikipedia.org/wiki/Guillemet), like so `«variable»`. To type these character, press <kbd>option</kbd><kbd>(shift)</kbd><kbd>backslash (\\)</kbd> on macOS or <kbd>alt</kbd><kbd>0171</kbd> and <kbd>alt</kbd><kbd>0187</kbd> on Windows.
+  * `<variable>` clashes with XML
+  * `[variable]` clashes with arrays/lists
+  * `{variable}` clashes with objects/scopes
+  * `(variable)` clashes with mathematical operations
+
 ## License
 
 See [LICENSE](./LICENSE)


### PR DESCRIPTION
Add examples of the AWS Redshift `UNLOAD` command including a couple
of edge-cases that may be frequently encountered when using it.

Also add a tidbit to the `README.md` about variable notations.